### PR TITLE
Add block-send step

### DIFF
--- a/steps/message-send/README.md
+++ b/steps/message-send/README.md
@@ -2,6 +2,9 @@
 
 This [Slack](https://slack.com) step sends a message to a desired channel.
 
+This message can either be via the Slack Block API, or as a direct message - at least one must be used.
+If both are supplied, then behavior is defined by the Slack SDKs, with more info found [here](https://api.slack.com/methods/chat.postMessage#text_usage).
+
 In order to connect to Slack you will need to **Create a new Slack app** at [https://api.slack.com/apps/](https://api.slack.com/apps?new_app=1), then:
 
 * Give it a name like "Notifications from Relay.sh"

--- a/steps/message-send/spec.schema.json
+++ b/steps/message-send/spec.schema.json
@@ -27,13 +27,16 @@
     "message": {
       "type": "string",
       "description": "Message to send."
+    },
+    "blocks": {
+      "type": "string",
+      "description": "Slack API Blocks to send"
     }
   },
   "required": [
     "connection",
     "channel",
-    "username",
-    "message"
+    "username"
   ],
   "additionalProperties": false
 }

--- a/steps/message-send/step.yaml
+++ b/steps/message-send/step.yaml
@@ -20,14 +20,15 @@ schemas:
     source: file
     file: spec.schema.json
 examples:
-- summary: Send a message
-  content:
-    apiVersion: v1
-    kind: Step
-    name: send-message
-    image: relaysh/slack-step-message-send
-    spec:
-      channel: !Parameter slack-channel
-      connection: !Connection { type: slack, name: my-slack-account}
-      message: !Parameter message # Example: "hello Relay!"
-      username: !Parameter username # Example: "Relay Workflows"
+  - summary: Send a message
+    content:
+      apiVersion: v1
+      kind: Step
+      name: send-message
+      image: relaysh/slack-step-message-send
+      spec:
+        channel: !Parameter slack-channel
+        connection: !Connection { type: slack, name: my-slack-account }
+        message: !Parameter message # Example: "hello Relay!"
+        blocks: !Parameter blocks # Example: "[{"type": "section","text": {"type": "mrkdwn", "text": "Hello from Relay!"}}]"
+        username: !Parameter username # Example: "Relay Workflows"


### PR DESCRIPTION
This step expands slack step capabilities to support slack block API.
Instead of just supporting string messages, this allows more complex
formatting via the JSON api.